### PR TITLE
Bugfix for feo-time get_speed & improvement for set_speed_twice test

### DIFF
--- a/feo-time/src/lib.rs
+++ b/feo-time/src/lib.rs
@@ -118,7 +118,7 @@ pub fn speed(factor: i32) {
 /// Get the current speed factor if set. Otherwise return None.
 pub fn get_speed() -> Option<i32> {
     let factor = FACTOR.load(Ordering::Relaxed);
-    (factor == 0).then_some(factor)
+    (factor != 0).then_some(factor)
 }
 
 impl Instant {

--- a/feo-time/src/tests.rs
+++ b/feo-time/src/tests.rs
@@ -268,7 +268,7 @@ fn big_math() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "speed can be set only once")]
 fn set_speed_twice() {
     assert!(crate::get_speed().is_none());
     crate::speed(2);


### PR DESCRIPTION
* return factor if its not equal 0 else None
* adapt test for setting speed twice to expect correct error msg