### PR TITLE
Updated tokio version to avoid known security issue with older versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,6 +900,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,9 +964,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libloading"
@@ -1001,7 +1012,7 @@ dependencies = [
  "feo-logger",
  "feo-time",
  "futures",
- "socket2",
+ "socket2 0.5.8",
  "tokio",
  "tokio-seqpacket",
  "tokio-util",
@@ -1501,6 +1512,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1606,18 +1627,20 @@ checksum = "2fde9a76dac5751480f711f327371c809d7f8a9f036436e6237d67859adbf3bd"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
+ "io-uring",
  "libc",
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "slab",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1644,9 +1667,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde = "1.0.217"
 serde_json = "1.0.1"
 socket2 = "0.5.8"
 time = { version = "0.3.37", features = ["formatting", "macros", "serde"] }
-tokio = { version = "1.42.0", features = [
+tokio = { version = "1.47.1", features = [
     "rt",
     "macros",
     "sync",
@@ -59,7 +59,7 @@ tokio = { version = "1.42.0", features = [
     "signal",
 ] }
 tokio-seqpacket = "0.8.0"
-tokio-util = { version = "0.7.13", features = ["codec", "net"] }
+tokio-util = { version = "0.7.16", features = ["codec", "net"] }
 tracing = { version = "0.1.41", features = [
     "attributes",
 ], default-features = false }


### PR DESCRIPTION
originates from CR #134708